### PR TITLE
Provide a binary without a version reference in the filename #13 (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - `Invoke-Terraform` recursively searches up for `.terraform-version` stopping at root ([#12](https://github.com/pearcec/Invoke-Terraform/issues/12))
+- Provide a binary without a version reference in the filename ([#13](https://github.com/pearcec/Invoke-Terraform/issues/13))
 
 ## [0.4.0]
 

--- a/Invoke-Terraform/Configuration.psd1
+++ b/Invoke-Terraform/Configuration.psd1
@@ -1,8 +1,9 @@
 @{
     TFPath                     = Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath 'bin'
-    TFVersion                  = '0.14.7'
+    TFVersion                  = '0.15.0'
     ReleaseUrl                 = 'https://releases.hashicorp.com/terraform'
     AutoDownload               = $false
+    AutoStableBinary           = $false
 
     HashiCorpPGPThumbprint     = '91A6E7F85D05C65630BEF18951852D87348FFC4C'
     HashiCorpPGPKeyId          = '0x51852D87348FFC4C'

--- a/Invoke-Terraform/Invoke-Terraform.psd1
+++ b/Invoke-Terraform/Invoke-Terraform.psd1
@@ -71,10 +71,13 @@
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = @(
         'Confirm-TerraformHashicorpKey'
+        'Get-TerraformStableBinary'
         'Get-TerraformConfiguration'
         'Install-Terraform'
         'Invoke-Terraform'
         'Set-TerraformAutoDownload'
+        'Set-TerraformAutoStableBinary'
+        'Set-TerraformStableBinary'
         'Set-TerraformConfiguration'
         'Set-TerraformSquelchChecksumWarning'
         'Set-TerraformVersion'

--- a/Invoke-Terraform/Private/Get-TerraformZip.ps1
+++ b/Invoke-Terraform/Private/Get-TerraformZip.ps1
@@ -1,4 +1,4 @@
-Function Get-TerraformBinary {
+Function Get-TerraformZip {
     param(
         [parameter(Mandatory)]
         [string]$TFVersion,

--- a/Invoke-Terraform/Private/Install-TerraformBinary.ps1
+++ b/Invoke-Terraform/Private/Install-TerraformBinary.ps1
@@ -6,10 +6,10 @@ Function Install-TerraformBinary {
         [switch]$SkipCodeSignature = $False
     )
 
-    $zipPath = Get-TerraformBinary -TFVersion $TFVersion -SkipChecksum:$SkipChecksum
+    $zipPath = Get-TerraformZip -TFVersion $TFVersion -SkipChecksum:$SkipChecksum
 
     try {
-        Copy-TerraformBinary -ZipPath $zipPath
+        Copy-TerraformBinary -TFVersion $TFVersion -ZipPath $zipPath
     } catch {
         Write-Error "Unable to copy binary from $zipPath."
         throw $_

--- a/Invoke-Terraform/Public/Get-TerraformStableBinary.ps1
+++ b/Invoke-Terraform/Public/Get-TerraformStableBinary.ps1
@@ -1,0 +1,42 @@
+<#
+    .SYNOPSIS
+        Get stable path for terraform binary (ie. terraform.exe or terraform)
+    .DESCRIPTION
+        Get stable path for terraform binary (ie. terraform.exe or terraform)
+    .EXAMPLE
+        Get-TerraformStableBinary
+
+        Returns stable path for terraform binary
+    .INPUTS
+        None. You cannot pipe objects to Set-TerraformStableBinary.
+    .OUTPUTS
+        Returns a path.
+    .LINK
+        Set-TerraformStableBinary
+    .LINK
+        Online version: https://github.com/pearcec/Invoke-Terraform
+#>
+function Get-TerraformStableBinary {
+
+    $installPath = (Get-TerraformConfiguration).TFPath
+    $binary = 'terraform'
+    if ($isWindows) {
+        $binary += '.exe'
+    }
+    $binPath = Join-Path -Path $installPath -ChildPath $binary
+
+    if (Test-Path $binPath -PathType leaf ) {
+        return $binPath
+    }
+    Write-Error @"
+Terraform static binary not set. Run either:
+    - Set-TerraformStableBinary
+or:
+    - Set-TerraformAutoStableBinary `$true
+    - Set-TerraformVersion -TFVersion:[TFversion]
+or:
+    - Set-TerraformAutoStableBinary `$true
+    - Install-Terraform
+"@
+    throw ''
+}

--- a/Invoke-Terraform/Public/Invoke-Terraform.ps1
+++ b/Invoke-Terraform/Public/Invoke-Terraform.ps1
@@ -66,9 +66,9 @@ Function Invoke-Terraform {
             Install-Terraform -TFVersion $TFVersion
         } else {
             Write-Error @"
-Terraform version $($TFVersion) not installed. Run either
-
+Terraform version $($TFVersion) not installed. Run either:
     - Install-Terraform -TFVersion $($TFVersion)
+or:
     - Set-TerraformAutoDownload `$true
 "@
             throw ''

--- a/Invoke-Terraform/Public/Set-TerraformAutoStableBinary.ps1
+++ b/Invoke-Terraform/Public/Set-TerraformAutoStableBinary.ps1
@@ -1,0 +1,41 @@
+<#
+    .SYNOPSIS
+        Set auto switch binary configuration.
+    .DESCRIPTION
+        Set auto switch binary configuration.
+    .PARAMETER AutoStableBinary
+        Either true or false.
+    .EXAMPLE
+        Set-TerraformAutoStableBinary $true
+
+        Sets auto switch binary configuration to true
+    .INPUTS
+        None. You cannot pipe objects to Set-TerraformAutoStableBinary.
+    .OUTPUTS
+        None. Set-TerraformAutoStableBinary returns nothing.
+    .LINK
+        Get-TerraformConfiguration
+    .LINK
+        Online version: https://github.com/pearcec/Invoke-Terraform
+#>
+function Set-TerraformAutoStableBinary {
+    [cmdletbinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param(
+        [parameter(Mandatory)]
+        [boolean]$AutoStableBinary
+    )
+    begin {
+        Write-Debug -Message 'Beginning'
+        $configurationPath = Get-ConfigurationPath
+    }
+
+    process {
+        if ($PSCmdlet.ShouldProcess($configurationPath, "Setting AutoStableBinary configuration to $($AutoStableBinary)")) {
+            Write-Verbose "Setting AutoStableBinary configuration to $($AutoStableBinary)"
+            Set-TerraformConfiguration @{ AutoStableBinary = $AutoStableBinary } -Confirm:$False
+        }
+    }
+    end {
+        Write-Debug -Message 'Ending'
+    }
+}

--- a/Invoke-Terraform/Public/Set-TerraformStableBinary.ps1
+++ b/Invoke-Terraform/Public/Set-TerraformStableBinary.ps1
@@ -1,0 +1,57 @@
+<#
+    .SYNOPSIS
+        Set version for stable terraform binary (ie. terraform.exe or terraform)
+    .DESCRIPTION
+        Set version for stable terraform binary (ie. terraform.exe or terraform)
+    .PARAMETER TFVersion
+        The preferred version.
+    .PARAMETER SkipChecksum
+        Skip release archive checksum verification.
+    .PARAMETER SkipCodeSignature
+        Skip code signature verifcation.
+    .EXAMPLE
+        Set-TerraformStableBinary
+
+        Sets the latest terraform version to the static name terraform.exe or terraform
+    .EXAMPLE
+        Set-TerraformStableBinary -TFVersion 0.14.7
+
+        Sets terraform version 0.14.7 to the static name terraform.exe or terraform
+    .INPUTS
+        None. You cannot pipe objects to Set-TerraformStableBinary.
+    .OUTPUTS
+        None. Set-TerraformStableBinary returns nothing.
+    .LINK
+        Get-TerraformStableBinary
+    .LINK
+        Online version: https://github.com/pearcec/Invoke-Terraform
+#>
+function Set-TerraformStableBinary {
+    [cmdletbinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param(
+        [string]$TFVersion,
+        [switch]$SkipChecksum = $False,
+        [switch]$SkipCodeSignature = $False
+    )
+
+    begin {
+        Write-Debug -Message 'Beginning'
+        if (-not $TFVersion) {
+            $TFVersion = Get-TerraformLatestRelease
+        }
+    }
+
+    process {
+        if ($PSCmdlet.ShouldProcess($configurationPath, "Setting static terraform binary to TFVesion $($TFVersion)")) {
+            if (-not (Test-TerraformPath -TFVersion $TFVersion)) {
+                Write-Verbose "Installing terraform version $($TFVersion)"
+                Install-TerraformBinary -TFVersion $TFVersion -SkipChecksum:$SkipChecksum -SkipCodeSignature:$SkipCodeSignature
+            }
+            Copy-TerraformBinary -TFVersion $TFVersion
+        }
+    }
+
+    end {
+        Write-Debug -Message 'Ending'
+    }
+}

--- a/Invoke-Terraform/Public/Set-TerraformVersion.ps1
+++ b/Invoke-Terraform/Public/Set-TerraformVersion.ps1
@@ -27,12 +27,16 @@ Function Set-TerraformVersion {
     begin {
         Write-Debug -Message 'Beginning'
         $configurationPath = Get-ConfigurationPath
+        $AutoStableBinary = (Get-TerraformConfiguration).AutoStableBinary
     }
 
     process {
         if ($PSCmdlet.ShouldProcess($configurationPath, "Setting TFVesion configuration version to $($TFVersion)")) {
             Write-Verbose "Setting TFVersion configuration version to $($TFVersion)"
             Set-TerraformConfiguration @{ TFVersion = $TfVersion } -Confirm:$False
+        }
+        if ($AutoStableBinary) {
+            Set-TerraformStableBinary -TFVersion $TFVersion -Confirm:$ConfirmPreference
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A PowerShell module to run terraform.
 
-| GitHub Actions | PSGallery | License |
-|----------------|-----------|---------|
-[![GitHub Actions Status][github-actions-badge]][github-actions-build] | [![PowerShell Gallery][psgallery-badge]][psgallery] | [![License][license-badge]][license]
+| GitHub Actions                                                         | PSGallery                                           | License                              |
+| ---------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------ |
+| [![GitHub Actions Status][github-actions-badge]][github-actions-build] | [![PowerShell Gallery][psgallery-badge]][psgallery] | [![License][license-badge]][license] |
 
 ## Overview
 
@@ -31,25 +31,32 @@ terraform -TFVersion 0.14.8 -version
 ```
 
 ## Commands 
-| Command | Description |
-|---------|-------------|
-Confirm-TerraformHashicorpKey | Confirm the HashiCorp Security Key in gpg.
-Get-TerraformPreference | List user preferences.
-Install-Terraform | Install a version of terraform.
-Invoke-Terraform | Run terraform.
-Set-TerraformPreference | Set Invoke-Terraform user preferences.
-Switch-Terraform | Change default version of terraform to invoke.
-Uninstall-Terraform | Uninstall a version of terraform.
-terraform | Invoke-Terraform alias.
+| Command                             | Description                                                                                |
+| ----------------------------------- | ------------------------------------------------------------------------------------------ |
+| Confirm-TerraformHashicorpKey       | Confirm the HashiCorp Security Key in gpg.                                                 |
+| Get-TerraformConfiguration          | Get Invoke-Terraform configurations.                                                       |
+| Get-TerraformStableBinary           | Get the path for the current static installation of terraform binary.                      |
+| Install-Terraform                   | Install a version of terraform.                                                            |
+| Invoke-Terraform                    | Run terraform.                                                                             |
+| Set-TerraformAutoDownload           | Set Invoke-Terraform to automatically download terraform if needed.                        |
+| Set-TerraformAutoStableBinary       | Set Set-TerraformVersion to automatically switch static  installation of terraform binary. |
+| Set-TerraformConfiguration          | Set Invoke-Terraform configurations.                                                       |
+| Set-TerraformStableBinary           | Set version of static installation of terraform binary.                                    |
+| Set-TerraformSquelchChecksumWarning | Squelch checksum warnings.                                                                 |
+| Set-TerraformVersion                | Change default version of terraform to invoke.                                             |
+| Switch-Terraform                    | Set-TerraformVersion alias.                                                                |
+| Uninstall-Terraform                 | Uninstall a version of terraform.                                                          |
+| terraform                           | Invoke-Terraform alias.                                                                    |
 
 ## User Preferences
 
-| Name | Description |
-|------|-------------|
-Path | Installation location for terraform binaries. Defaults to $HOME\bin.
-TFVersion | Preferred version of terraform.
-ReleaseUrl | Defaults to https://releases.hashicorp.com/terraform
-AutoDownload | Automatically download terraform when invoking if the binary is not installed. Defaults to false.
+| Name             | Description                                                                                                                        |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Path             | Installation location for terraform binaries. Defaults to $HOME\bin.                                                               |
+| TFVersion        | Preferred version of terraform.                                                                                                    |
+| ReleaseUrl       | Defaults to https://releases.hashicorp.com/terraform                                                                               |
+| AutoDownload     | Automatically download terraform when invoking if the binary is not installed. Defaults to false.                                  |
+| AutoStableBinary | Automatically switch the static binary to the TFVersion called with Set-TerraformVersion (ie Switch-Terraform). Defaults to false. |
 
 ## Verification
 
@@ -58,20 +65,43 @@ HashiCorp provides a few methods of [verification](https://www.hashicorp.com/sec
 The default behavior is to always run code signature verification every time terraform is run when supported and checksums when binaries are installed.  By default HashiCorp PGP Key is import from keyserver.ubuntu.com.  The following additional preferences may be used to validate the signatures provide by this module, and adjust the settings according to your 
 security tolerance:
 
-| Name | Description |
-|------|-------------|
-HashiCorpPGPThumbprint     | 91A6E7F85D05C65630BEF18951852D87348FFC4C
-HashiCorpPGPKeyId          | 0x51852D87348FFC4C
-HashiCorpTeamIdentifier    | D38WU7D763
-HashiCorpWindowsThumbprint | 35AB9FC834D217E9E7B1778FB1B97AF7C73792F2
-PGPKeyServer               | keyserver.ubuntu.com
-SquelchChecksumWarning     | Turn off warning from gpg when HashiCorp imported key has not be signed. Defaults to false.
-SkipChecksum               | Turn off release archive checksum verification via gpg. Defaults to false.
-SkipCodeSignature          | Turn off code signature verification. Defaults to false.
+| Name                       | Description                                                                                 |
+| -------------------------- | ------------------------------------------------------------------------------------------- |
+| HashiCorpPGPThumbprint     | 91A6E7F85D05C65630BEF18951852D87348FFC4C                                                    |
+| HashiCorpPGPKeyId          | 0x51852D87348FFC4C                                                                          |
+| HashiCorpTeamIdentifier    | D38WU7D763                                                                                  |
+| HashiCorpWindowsThumbprint | 35AB9FC834D217E9E7B1778FB1B97AF7C73792F2                                                    |
+| PGPKeyServer               | keyserver.ubuntu.com                                                                        |
+| SquelchChecksumWarning     | Turn off warning from gpg when HashiCorp imported key has not be signed. Defaults to false. |
+| SkipChecksum               | Turn off release archive checksum verification via gpg. Defaults to false.                  |
+| SkipCodeSignature          | Turn off code signature verification. Defaults to false.                                    |
 
 ## Other behavior
 
 By default *Invoke-Terraform* searches the current working directory for the file `.terraform-version`.  This file contains the preferred version of terraform. Store this file with your terraform project to seamlessly invoke the required version of terraform.
+
+## Best Practice
+
+### $ENV:Path, $PATH
+
+It is recommended the `terraform` binary be removed from `$ENV:Path`.  Even though the powershell alias overrides what is available in the `Path`, unexpected usage could occur if this module was not loaded. This eliminates the chance of running an unplanned version.
+
+### VSCode
+
+If terraform is removed from your path as recommended, the [vscode-terraform](https://github.com/hashicorp/vscode-terraform) extension breaks. The `Set-TerraformStableBinary` has been added to provide a stable path name.  Run `Get-TerraformStableBinary` to retrieve the path. Use the following example for vscode settings: 
+
+```json
+"terraform.languageServer": {
+    "external": true,
+    "pathToBinary": "",
+    "args": [
+        "serve",
+        "-tf-exec=C:/users/pearcec/Documents/PowerShell/Modules/Invoke-Terraform/bin/terraform.exe",
+    ],
+    "maxNumberOfProblems": 100,
+    "trace.server": "off"
+}
+```
 
 [github-actions-badge]: https://github.com/pearcec/Invoke-Terraform/workflows/CI/badge.svg
 [github-actions-build]: https://github.com/pearcec/Invoke-Terraform/actions

--- a/docs/en-US/Get-TerraformBinary.md
+++ b/docs/en-US/Get-TerraformBinary.md
@@ -1,0 +1,51 @@
+---
+external help file: Invoke-Terraform-help.xml
+Module Name: Invoke-Terraform
+online version:
+schema: 2.0.0
+---
+
+# Get-TerraformBinary
+
+## SYNOPSIS
+Get stable path for terraform binary (ie.
+terraform.exe or terraform)
+
+## SYNTAX
+
+```
+Get-TerraformBinary [<CommonParameters>]
+```
+
+## DESCRIPTION
+Get stable path for terraform binary (ie.
+terraform.exe or terraform)
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Get-TerraformBinary
+```
+
+Returns stable path for terraform binary
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None. You cannot pipe objects to Set-TerraformBinary.
+## OUTPUTS
+
+### Returns a path.
+## NOTES
+
+## RELATED LINKS
+
+[Set-TerraformBinary]()
+
+[Online version: https://github.com/pearcec/Invoke-Terraform]()
+

--- a/docs/en-US/Get-TerraformStableBinary.md
+++ b/docs/en-US/Get-TerraformStableBinary.md
@@ -1,0 +1,48 @@
+---
+external help file: Invoke-Terraform-help.xml
+Module Name: Invoke-Terraform
+online version:
+schema: 2.0.0
+---
+
+# Get-TerraformStableBinary
+
+## SYNOPSIS
+Get stable path for terraform binary (ie.
+terraform.exe or terraform)
+
+## SYNTAX
+
+```
+Get-TerraformStableBinary
+```
+
+## DESCRIPTION
+Get stable path for terraform binary (ie.
+terraform.exe or terraform)
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Get-TerraformStableBinary
+```
+
+Returns stable path for terraform binary
+
+## PARAMETERS
+
+## INPUTS
+
+### None. You cannot pipe objects to Set-TerraformStableBinary.
+## OUTPUTS
+
+### Returns a path.
+## NOTES
+
+## RELATED LINKS
+
+[Set-TerraformStableBinary]()
+
+[Online version: https://github.com/pearcec/Invoke-Terraform]()
+

--- a/docs/en-US/Set-TerraformAutoStableBinary.md
+++ b/docs/en-US/Set-TerraformAutoStableBinary.md
@@ -1,0 +1,95 @@
+---
+external help file: Invoke-Terraform-help.xml
+Module Name: Invoke-Terraform
+online version:
+schema: 2.0.0
+---
+
+# Set-TerraformAutoStableBinary
+
+## SYNOPSIS
+Set auto switch binary configuration.
+
+## SYNTAX
+
+```
+Set-TerraformAutoStableBinary [-AutoStableBinary] <Boolean> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Set auto switch binary configuration.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Set-TerraformAutoStableBinary $true
+```
+
+Sets auto switch binary configuration to true
+
+## PARAMETERS
+
+### -AutoStableBinary
+Either true or false.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None. You cannot pipe objects to Set-TerraformAutoStableBinary.
+## OUTPUTS
+
+### None. Set-TerraformAutoStableBinary returns nothing.
+## NOTES
+
+## RELATED LINKS
+
+[Get-TerraformConfiguration]()
+
+[Online version: https://github.com/pearcec/Invoke-Terraform]()
+

--- a/docs/en-US/Set-TerraformAutoSwitchBinary.md
+++ b/docs/en-US/Set-TerraformAutoSwitchBinary.md
@@ -1,0 +1,95 @@
+---
+external help file: Invoke-Terraform-help.xml
+Module Name: Invoke-Terraform
+online version:
+schema: 2.0.0
+---
+
+# Set-TerraformAutoSwitchBinary
+
+## SYNOPSIS
+Set auto auto switch binary configuration.
+
+## SYNTAX
+
+```
+Set-TerraformAutoSwitchBinary [-AutoSwitchBinary] <Boolean> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Set auto auto switch binary configuration.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Set-TerraformAutoSwitchBinary $true
+```
+
+Sets auto switch binary configuration to true
+
+## PARAMETERS
+
+### -AutoSwitchBinary
+Either true or false.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None. You cannot pipe objects to Set-TerraformAutoSwitchBinary.
+## OUTPUTS
+
+### None. Set-TerraformAutoSwitchBinary returns nothing.
+## NOTES
+
+## RELATED LINKS
+
+[Get-TerraformConfiguration]()
+
+[Online version: https://github.com/pearcec/Invoke-Terraform]()
+

--- a/docs/en-US/Set-TerraformBinary.md
+++ b/docs/en-US/Set-TerraformBinary.md
@@ -1,0 +1,135 @@
+---
+external help file: Invoke-Terraform-help.xml
+Module Name: Invoke-Terraform
+online version:
+schema: 2.0.0
+---
+
+# Set-TerraformBinary
+
+## SYNOPSIS
+Set version for stable terraform binary (ie.
+terraform.exe or terraform)
+
+## SYNTAX
+
+```
+Set-TerraformBinary [[-TFVersion] <String>] [-SkipChecksum] [-SkipCodeSignature] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Set version for stable terraform binary (ie.
+terraform.exe or terraform)
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Set-TerraformBinary
+```
+
+Sets the latest terraform version to the static name terraform.exe or terraform
+
+### EXAMPLE 2
+```
+Set-TerraformBinary -TFVersion 0.14.7
+```
+
+Sets terraform version 0.14.7 to the static name terraform.exe or terraform
+
+## PARAMETERS
+
+### -TFVersion
+The preferred version.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipChecksum
+Skip release archive checksum verification.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCodeSignature
+Skip code signature verifcation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None. You cannot pipe objects to Set-TerraformBinary.
+## OUTPUTS
+
+### None. Set-TerraformBinary returns nothing.
+## NOTES
+
+## RELATED LINKS
+
+[Get-TerraformBinary]()
+
+[Online version: https://github.com/pearcec/Invoke-Terraform]()
+

--- a/docs/en-US/Set-TerraformStableBinary.md
+++ b/docs/en-US/Set-TerraformStableBinary.md
@@ -1,0 +1,135 @@
+---
+external help file: Invoke-Terraform-help.xml
+Module Name: Invoke-Terraform
+online version:
+schema: 2.0.0
+---
+
+# Set-TerraformStableBinary
+
+## SYNOPSIS
+Set version for stable terraform binary (ie.
+terraform.exe or terraform)
+
+## SYNTAX
+
+```
+Set-TerraformStableBinary [[-TFVersion] <String>] [-SkipChecksum] [-SkipCodeSignature] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Set version for stable terraform binary (ie.
+terraform.exe or terraform)
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Set-TerraformStableBinary
+```
+
+Sets the latest terraform version to the static name terraform.exe or terraform
+
+### EXAMPLE 2
+```
+Set-TerraformStableBinary -TFVersion 0.14.7
+```
+
+Sets terraform version 0.14.7 to the static name terraform.exe or terraform
+
+## PARAMETERS
+
+### -TFVersion
+The preferred version.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipChecksum
+Skip release archive checksum verification.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCodeSignature
+Skip code signature verifcation.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None. You cannot pipe objects to Set-TerraformStableBinary.
+## OUTPUTS
+
+### None. Set-TerraformStableBinary returns nothing.
+## NOTES
+
+## RELATED LINKS
+
+[Get-TerraformStableBinary]()
+
+[Online version: https://github.com/pearcec/Invoke-Terraform]()
+

--- a/tests/unit/Get-TerraformConfiguration.tests.ps1
+++ b/tests/unit/Get-TerraformConfiguration.tests.ps1
@@ -17,6 +17,9 @@ Describe 'Get-TerraformConfiguration' {
     It 'has default AutoDownload' {
         $script:setting.AutoDownload | Should -Be $script:defaultConfiguration.AutoDownload
     }
+    It 'has default AutoStableBinary' {
+        $script:setting.AutoStableBinary | Should -Be $script:defaultConfiguration.AutoStableBinary
+    }
     It 'has default HashiCorpPGPThumbprint' {
         $script:setting.HashiCorpPGPThumbprint | Should -Be $script:defaultConfiguration.HashiCorpPGPThumbprint
     }

--- a/tests/unit/Invoke-Terraform.tests.ps1
+++ b/tests/unit/Invoke-Terraform.tests.ps1
@@ -11,19 +11,19 @@ Describe 'Invoke-Terraform' {
     }
     It 'has version defined by configuration 0.14.5' {
         Set-TerraformVersion -TFVersion 0.14.5 -Confirm:$false
-        Set-TerraformAutoDownload -AutoDownload $true -Confirm:$false
+        Set-TerraformAutoDownload -AutoDownload:$true -Confirm:$false
         Invoke-Terraform -version | Out-File TestDrive:\version.txt
         (Get-Content TestDrive:\version.txt)[0] | Should -Match 0.14.5
     }
     It 'has version passed 0.14.6' {
         Set-TerraformVersion -TFVersion 0.14.5 -Confirm:$false
-        Set-TerraformAutoDownload -AutoDownload $true -Confirm:$false
+        Set-TerraformAutoDownload -AutoDownload:$true -Confirm:$false
         Invoke-Terraform 0.14.6 -version | Out-File TestDrive:\version-0.14.6.txt
         (Get-Content TestDrive:\version-0.14.6.txt)[0] | Should -Match 0.14.6
     }
     It 'has version 0.14.1 from .terraform-version' {
         Set-TerraformVersion -TFVersion 0.14.5 -Confirm:$false
-        Set-TerraformAutoDownload -AutoDownload $true -Confirm:$false
+        Set-TerraformAutoDownload -AutoDownload:$true -Confirm:$false
         $terraformVersionFile = [IO.Path]::Combine('..', '.terraform-version') 
         '0.14.1' | Out-File -Path $terraformVersionFile
         Invoke-Terraform -version | Out-File TestDrive:\version-0.14.1.txt

--- a/tests/unit/Set-TerraformAutoStableBinary.tests.ps1
+++ b/tests/unit/Set-TerraformAutoStableBinary.tests.ps1
@@ -1,0 +1,13 @@
+Describe 'Set-TerraformAutoStableBinary' {
+    It 'has AutoStableBinary configuration set to true' {
+        Set-TerraformAutoStableBinary -AutoStableBinary $true -Confirm:$false
+        $setting = Get-TerraformConfiguration
+        $setting.AutoStableBinary | Should -Be $true 
+    }
+
+    It 'has AutoStableBinary configuration set to false' {
+        Set-TerraformAutoStableBinary -AutoStableBinary $false -Confirm:$false
+        $setting = Get-TerraformConfiguration
+        $setting.AutoStableBinary | Should -Be $false 
+    }
+}

--- a/tests/unit/Set-TerraformStableBinary.tests.ps1
+++ b/tests/unit/Set-TerraformStableBinary.tests.ps1
@@ -1,0 +1,30 @@
+Describe 'Set-TerraformStableBinary' {
+    BeforeAll {
+        $outputDir = [IO.Path]::Combine($ENV:BHProjectPath, 'Output')
+        $outputModDir = [IO.Path]::Combine($outputDir, $env:BHProjectName)
+        $outputBinDir = [IO.Path]::Combine($outputModDir, 'bin')
+
+        if (Test-Path $outputBinDir) {
+            Remove-Item -Recurse $outputBinDir
+        } 
+        New-Item $outputBinDir -ItemType directory
+    }
+    It 'has version passed 0.14.2' {
+        Set-TerraformStableBinary -TFVersion 0.14.2 -Confirm:$false
+        $testPathBin = Get-TerraformStableBinary
+        $test = & $testPathBin -version | Select-String -Pattern ('Terraform v{0}' -f '0.14.2') -Quiet
+        $test | Should -BeTrue
+    }
+    It 'has latest release' {
+        $headers = @{
+            Accept = 'application/vnd.github.v3+json'
+        }
+    
+        $response = Invoke-RestMethod 'https://api.github.com/repos/hashicorp/terraform/releases/latest' -Method 'GET' -Headers $headers
+        $latest = $response.name.substring(1)
+        Set-TerraformStableBinary -Confirm:$false
+        $testPathBin = Get-TerraformStableBinary
+        $test = & $testPathBin -version | Select-String -Pattern ('Terraform v{0}' -f $latest) -Quiet
+        $test | Should -BeTrue
+    }
+}

--- a/tests/unit/Set-TerraformVersion.tests.ps1
+++ b/tests/unit/Set-TerraformVersion.tests.ps1
@@ -1,7 +1,24 @@
 Describe 'Set-TerraformVersion' {
+    BeforeAll {
+        $outputDir = [IO.Path]::Combine($ENV:BHProjectPath, 'Output')
+        $outputModDir = [IO.Path]::Combine($outputDir, $env:BHProjectName)
+        $outputBinDir = [IO.Path]::Combine($outputModDir, 'bin')
+
+        if (Test-Path $outputBinDir) {
+            Remove-Item -Recurse $outputBinDir
+        } 
+        New-Item $outputBinDir -ItemType directory
+    }
     It 'has Terraform version configuration set to 0.14.8' {
         Set-TerraformVersion -TFVersion 0.14.8 -Confirm:$false
         $setting = Get-TerraformConfiguration
         $setting.TFVersion | Should -Be '0.14.8'
+    }
+    It 'has version passed 0.14.3' {
+        Set-TerraformAutoStableBinary -AutoStableBinary:$true -Confirm:$false
+        Set-TerraformVersion -TFVersion 0.14.3 -Confirm:$false
+        $testPathBin = Get-TerraformStableBinary
+        $test = & $testPathBin -version | Select-String -Pattern ('Terraform v{0}' -f '0.14.3') -Quiet
+        $test | Should -BeTrue
     }
 }


### PR DESCRIPTION
* Fixes #13
- Provide a binary without a version reference in the filename
- Set TFVersion on Copy-TerraformBinary (was pulling from Global scope and working somehow.)
- Modified Copy-TerraformBinary to support copying existing versioned installations to static installation.
- Refactor private function Copy-TerraformBinary to optionally use a ZipPath other defaults to stable path
- Renamed Get-TerraformZip to use Get-TerraformBinary in public namespace
- Add switch for automatically switch stable path with Set-TerraformVersion is invokved
- Tests