### PR TITLE
Terraform v1.0.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.6.0]
+
+### Fixed
+
+- Support for 1.0.0, making it the new default
+- Removed invalid description of Path from README.  `$HOME\bin` is no longer the default.
+
 ## [0.5.1]
 
 ### Security

--- a/Invoke-Terraform/Configuration.psd1
+++ b/Invoke-Terraform/Configuration.psd1
@@ -1,6 +1,6 @@
 @{
     TFPath                     = Join-Path -Path $PSScriptRoot -ChildPath '..' -AdditionalChildPath 'bin'
-    TFVersion                  = '0.15.1'
+    TFVersion                  = '1.0.0'
     ReleaseUrl                 = 'https://releases.hashicorp.com/terraform'
     AutoDownload               = $false
     AutoStableBinary           = $false

--- a/Invoke-Terraform/Invoke-Terraform.psd1
+++ b/Invoke-Terraform/Invoke-Terraform.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Invoke-Terraform.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.5.1'
+    ModuleVersion     = '0.6.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Invoke-Terraform/Public/Invoke-Terraform.ps1
+++ b/Invoke-Terraform/Public/Invoke-Terraform.ps1
@@ -38,7 +38,7 @@ Function Invoke-Terraform {
     # Due to positional parameters the first unnamed parameter
     # is passed to $TFVersion. This catches non version parameters
     # intended to pass to the terraform run.
-    if (-not ($TFVersion -match '^0\.\d\d?\.\d\d?$')) {
+    if (-not ($TFVersion -match '^\d\d?\.\d\d?\.\d\d?$')) {
         # Build $TFargs and null $TFVersion for default preference
         $TFargs = @($TFVersion) + $args
         $TFVersion = $null

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ terraform -TFVersion 0.14.8 -version
 
 | Name             | Description                                                                                                                        |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| Path             | Installation location for terraform binaries. Defaults to $HOME\bin.                                                               |
+| Path             | Installation location for terraform binaries.                                                               |
 | TFVersion        | Preferred version of terraform.                                                                                                    |
 | ReleaseUrl       | Defaults to https://releases.hashicorp.com/terraform                                                                               |
 | AutoDownload     | Automatically download terraform when invoking if the binary is not installed. Defaults to false.                                  |

--- a/tests/unit/Invoke-Terraform.tests.ps1
+++ b/tests/unit/Invoke-Terraform.tests.ps1
@@ -30,4 +30,13 @@ Describe 'Invoke-Terraform' {
         (Get-Content TestDrive:\version-0.14.1.txt)[0] | Should -Match 0.14.1
         Remove-Item -Force -Path $terraformVersionFile
     }
+    It 'has version 1.0.0' {
+        Set-TerraformVersion -TFVersion 1.0.0 -Confirm:$false
+        Set-TerraformAutoDownload -AutoDownload:$true -Confirm:$false
+        Set-TerraformVersion -TFVersion 0.14.1 -Confirm:$false
+        Invoke-Terraform 1.0.0 -version | Out-File TestDrive:\version-1.0.0.txt
+        (Get-Content TestDrive:\version-1.0.0.txt)[0] | Should -Match 'v1.0.0'
+        Invoke-Terraform -TFVersion 1.0.0 -version | Out-File TestDrive:\version-1.0.0.txt
+        (Get-Content TestDrive:\version-1.0.0.txt)[0] | Should -Match 'v1.0.0'
+    }
 }


### PR DESCRIPTION
* Update to support v1.0.0 making it the new default.
* Remove inaccurate description from README for Path.  It no longer default to $HOME\bin.
